### PR TITLE
release: finalize v0.3.1 version and docs consistency

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -24,8 +24,8 @@
 설치:
 
 ```pwsh
-dotnet add package SignalCandy.Core --version 0.3.0
-dotnet add package SignalCandy --version 0.3.0
+dotnet add package SignalCandy.Core --version 0.3.1
+dotnet add package SignalCandy --version 0.3.1
 ```
 
 ## ⚡ 빠른 시작 (5분)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This project generates portable C99 parser modules (headers/sources) from a `.db
 Install:
 
 ```pwsh
-dotnet add package SignalCandy.Core --version 0.3.0
-dotnet add package SignalCandy --version 0.3.0
+dotnet add package SignalCandy.Core --version 0.3.1
+dotnet add package SignalCandy --version 0.3.1
 ```
 
 ## ⚡ Quick Start (5 minutes)

--- a/src/Signal.CANdy.Core/Api.fs
+++ b/src/Signal.CANdy.Core/Api.fs
@@ -8,7 +8,7 @@ open Signal.CANdy.Core.Dbc
 open Signal.CANdy.Core.Codegen
 
 /// Returns the current library snapshot version. Placeholder until full API is moved.
-let version () = "0.3.1-alpha.1"
+let version () = "0.3.1"
 
 /// Parse a DBC file into IR. Stub for now.
 let parseDbc (path: string) : Result<Ir, ParseError> = Signal.CANdy.Core.Dbc.parseDbcFile path

--- a/src/Signal.CANdy.Core/README.NuGet.md
+++ b/src/Signal.CANdy.Core/README.NuGet.md
@@ -8,7 +8,7 @@ Core library for SignalCandy: parse DBC files, validate config, and generate C99
 ## Install
 
 ```
-dotnet add package SignalCandy.Core --version 0.3.0
+dotnet add package SignalCandy.Core --version 0.3.1
 ```
 
 ## Quick start (F#)

--- a/src/Signal.CANdy.Core/Signal.CANdy.Core.fsproj
+++ b/src/Signal.CANdy.Core/Signal.CANdy.Core.fsproj
@@ -12,7 +12,7 @@
   <PackageTags>CAN;DBC;codegen;C;F#;embedded</PackageTags>
   <PublishRepositoryUrl>true</PublishRepositoryUrl>
   <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-  <Version>0.3.1-alpha.1</Version>
+  <Version>0.3.1</Version>
   <PackageLicenseExpression>MIT</PackageLicenseExpression>
   <PackageReadmeFile>README.NuGet.md</PackageReadmeFile>
   <IncludeSymbols>true</IncludeSymbols>

--- a/src/Signal.CANdy/README.NuGet.md
+++ b/src/Signal.CANdy/README.NuGet.md
@@ -8,7 +8,7 @@ C#-friendly facade over SignalCandy Core. Wraps Result-based F# API with excepti
 ## Install
 
 ```
-dotnet add package SignalCandy --version 0.3.0
+dotnet add package SignalCandy --version 0.3.1
 ```
 
 ## Quick start (C#)

--- a/src/Signal.CANdy/Signal.CANdy.fsproj
+++ b/src/Signal.CANdy/Signal.CANdy.fsproj
@@ -12,7 +12,7 @@
   <PackageTags>CAN;DBC;codegen;C;F#;facade</PackageTags>
   <PublishRepositoryUrl>true</PublishRepositoryUrl>
   <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-  <Version>0.3.1-alpha.1</Version>
+  <Version>0.3.1</Version>
   <PackageLicenseExpression>MIT</PackageLicenseExpression>
   <PackageReadmeFile>README.NuGet.md</PackageReadmeFile>
   <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
## Summary
- set release version to `0.3.1` in both package projects and `Api.version()`
- update install snippets to `0.3.1` in README (EN/KO) and NuGet README files

## Why
This aligns all release-facing version references before creating the stable `v0.3.1` tag on `main`.

## Verification
- `fantomas --check src/ tests/`
- `dotnet build --configuration Release --nologo`
- `dotnet test --configuration Release -v minimal --nologo`