### PR TITLE
release: promote main version surface to 0.4.0

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -24,8 +24,8 @@
 설치:
 
 ```pwsh
-dotnet add package SignalCandy.Core --version 0.4.0-alpha.1
-dotnet add package SignalCandy --version 0.4.0-alpha.1
+dotnet add package SignalCandy.Core --version 0.4.0
+dotnet add package SignalCandy --version 0.4.0
 ```
 
 ## ⚡ 빠른 시작 (5분)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ This project generates portable C99 parser modules (headers/sources) from a `.db
 Install:
 
 ```pwsh
-dotnet add package SignalCandy.Core --version 0.4.0-alpha.1
-dotnet add package SignalCandy --version 0.4.0-alpha.1
+dotnet add package SignalCandy.Core --version 0.4.0
+dotnet add package SignalCandy --version 0.4.0
 ```
 
 ## ⚡ Quick Start (5 minutes)

--- a/Reports/20260316-1407_0.4.0_스테이블승격_준비.md
+++ b/Reports/20260316-1407_0.4.0_스테이블승격_준비.md
@@ -1,0 +1,50 @@
+## 📝 작업 요약
+
+- `origin/main`에 이미 머지된 `0.4.0-alpha.1` 통합 상태를 기준으로, stable release를 위한 공개 버전 표면을 **`0.4.0`**으로 승격할 준비를 수행했다.
+- release workflow가 `main` 계보의 태그만 허용한다는 점을 재확인했고, stable tag(`v0.4.0`)는 `main`의 prerelease 표면을 stable로 올린 뒤에만 찍어야 한다는 결론을 검증했다.
+
+## 🛠 변경 상세
+
+- 기준 상태 확인
+  - `origin/main` = `aaa6757` (`release: integrate dev into main for 0.4.0-alpha.1 (#15)`)
+  - 기존 prerelease 태그 `v0.4.0-alpha.1`는 이미 원격에 존재하며 dev 계보에서 생성된 태그임을 확인.
+- release workflow 점검
+  - `.github/workflows/release.yml`
+  - 태그 push 시 동작하며, tagged commit이 `origin/main`에 reachable 해야만 진행.
+  - `-`가 포함된 태그는 prerelease, 없는 태그는 stable release + NuGet publish 경로를 탐.
+- stable 승격용 공개 버전 표면 변경
+  - `src/Signal.CANdy.Core/Signal.CANdy.Core.fsproj` → `0.4.0`
+  - `src/Signal.CANdy/Signal.CANdy.fsproj` → `0.4.0`
+  - `src/Signal.CANdy.Core/Api.fs` → `version () = "0.4.0"`
+  - `README.md`, `README.ko.md` 설치 예시 → `0.4.0`
+  - `src/Signal.CANdy.Core/README.NuGet.md`, `src/Signal.CANdy/README.NuGet.md` 설치 예시 → `0.4.0`
+- 작업 브랜치
+  - `release/stable-0.4.0`를 `origin/main`에서 생성하여, stale local `main`이 아니라 실제 원격 main 기반으로 작업.
+
+## ✅ 테스트 결과
+
+- 버전 표면 확인
+  - authoritative surface에서 `0.4.0-alpha.1` 잔존 없음 확인
+  - `0.4.0`는 7개 공개/권위 파일에 반영됨 확인
+  - historical report 파일 내 `0.4.0-alpha.1` 표기는 이력으로 유지
+- 진단
+  - `src/Signal.CANdy.Core/Api.fs` LSP diagnostics → 이상 없음
+- 빌드
+  - `dotnet build --configuration Release --nologo` ✅ 통과
+- 테스트
+  - `dotnet test --configuration Release -v minimal --nologo` ✅ 통과
+  - `Signal.CANdy.Core.Tests`: 130/130 통과
+  - `Generator.Tests`: 27/27 통과
+- 패키지 검증
+  - `dotnet pack -c Release src/Signal.CANdy.Core/Signal.CANdy.Core.fsproj -o artifacts-stablecheck` ✅
+  - `dotnet pack -c Release src/Signal.CANdy/Signal.CANdy.fsproj -o artifacts-stablecheck` ✅
+  - 생성 패키지명 `SignalCandy.Core.0.4.0.nupkg`, `SignalCandy.0.4.0.nupkg` 확인 후 임시 산출물 삭제
+
+## ⏭ 다음 계획
+
+- 다음 단계는 동일 세션에서 이어서 수행:
+  1. stable 승격 변경을 atomic commit으로 정리
+  2. `release/stable-0.4.0` 브랜치를 push
+  3. `main`으로 minimal stable-promotion PR 생성/머지
+  4. 머지된 `main` 커밋에 `v0.4.0` 태그를 push하여 Release workflow 실행
+- 제품 backlog 관점의 다음 활성 항목은 여전히 `Plans/ROADMAP.md`의 **Oracle reference decoder 비호환 DBC 대응 전략**이다.

--- a/src/Signal.CANdy.Core/Api.fs
+++ b/src/Signal.CANdy.Core/Api.fs
@@ -8,7 +8,7 @@ open Signal.CANdy.Core.Dbc
 open Signal.CANdy.Core.Codegen
 
 /// Returns the current library snapshot version. Placeholder until full API is moved.
-let version () = "0.4.0-alpha.1"
+let version () = "0.4.0"
 
 /// Parse a DBC file into IR. Stub for now.
 let parseDbc (path: string) : Result<Ir, ParseError> = Signal.CANdy.Core.Dbc.parseDbcFile path

--- a/src/Signal.CANdy.Core/README.NuGet.md
+++ b/src/Signal.CANdy.Core/README.NuGet.md
@@ -8,7 +8,7 @@ Core library for SignalCandy: parse DBC files, validate config, and generate C99
 ## Install
 
 ```
-dotnet add package SignalCandy.Core --version 0.4.0-alpha.1
+dotnet add package SignalCandy.Core --version 0.4.0
 ```
 
 ## Quick start (F#)

--- a/src/Signal.CANdy.Core/Signal.CANdy.Core.fsproj
+++ b/src/Signal.CANdy.Core/Signal.CANdy.Core.fsproj
@@ -12,7 +12,7 @@
   <PackageTags>CAN;DBC;codegen;C;F#;embedded</PackageTags>
   <PublishRepositoryUrl>true</PublishRepositoryUrl>
   <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-  <Version>0.4.0-alpha.1</Version>
+  <Version>0.4.0</Version>
   <PackageLicenseExpression>MIT</PackageLicenseExpression>
   <PackageReadmeFile>README.NuGet.md</PackageReadmeFile>
   <IncludeSymbols>true</IncludeSymbols>

--- a/src/Signal.CANdy/README.NuGet.md
+++ b/src/Signal.CANdy/README.NuGet.md
@@ -8,7 +8,7 @@ C#-friendly facade over SignalCandy Core. Wraps Result-based F# API with excepti
 ## Install
 
 ```
-dotnet add package SignalCandy --version 0.4.0-alpha.1
+dotnet add package SignalCandy --version 0.4.0
 ```
 
 ## Quick start (C#)

--- a/src/Signal.CANdy/Signal.CANdy.fsproj
+++ b/src/Signal.CANdy/Signal.CANdy.fsproj
@@ -12,7 +12,7 @@
   <PackageTags>CAN;DBC;codegen;C;F#;facade</PackageTags>
   <PublishRepositoryUrl>true</PublishRepositoryUrl>
   <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-  <Version>0.4.0-alpha.1</Version>
+  <Version>0.4.0</Version>
   <PackageLicenseExpression>MIT</PackageLicenseExpression>
   <PackageReadmeFile>README.NuGet.md</PackageReadmeFile>
   <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
## Summary
- promote the merged `main` branch version surface from `0.4.0-alpha.1` to stable `0.4.0`
- align package metadata, `Api.version()`, root READMEs, and NuGet READMEs with the stable release target
- prepare `main` for a clean `v0.4.0` stable tag and stable Release workflow execution

## Validation
- `dotnet build --configuration Release --nologo`
- `dotnet test --configuration Release -v minimal --nologo`
- `dotnet pack -c Release src/Signal.CANdy.Core/Signal.CANdy.Core.fsproj -o artifacts-stablecheck`
- `dotnet pack -c Release src/Signal.CANdy/Signal.CANdy.fsproj -o artifacts-stablecheck`

## Notes
- this is a minimal follow-up PR after the already-merged integration PR #15
- prerelease history remains documented in reports and the existing `v0.4.0-alpha.1` tag; this PR only promotes the authoritative public version surface on main